### PR TITLE
Unify kernels for basic and nested affine for loop

### DIFF
--- a/include/hcl/Transforms/Passes.h
+++ b/include/hcl/Transforms/Passes.h
@@ -28,6 +28,7 @@ bool applyLegalizeCast(ModuleOp &module);
 bool applyRemoveStrideMap(ModuleOp &module);
 bool applyMemRefDCE(ModuleOp &module);
 bool applyDataPlacement(ModuleOp &module);
+ModuleOp applyUnifyKernels(ModuleOp &module1, ModuleOp &module2);
 
 /// Registers all HCL transformation passes
 void registerHCLPasses();

--- a/include/hcl/Transforms/Passes.h
+++ b/include/hcl/Transforms/Passes.h
@@ -28,7 +28,7 @@ bool applyLegalizeCast(ModuleOp &module);
 bool applyRemoveStrideMap(ModuleOp &module);
 bool applyMemRefDCE(ModuleOp &module);
 bool applyDataPlacement(ModuleOp &module);
-ModuleOp applyUnifyKernels(ModuleOp &module1, ModuleOp &module2);
+ModuleOp applyUnifyKernels(ModuleOp &module1, ModuleOp &module2, MLIRContext *context);
 
 /// Registers all HCL transformation passes
 void registerHCLPasses();

--- a/lib/Bindings/Python/HCLModule.cpp
+++ b/lib/Bindings/Python/HCLModule.cpp
@@ -157,10 +157,11 @@ static bool memRefDCE(MlirModule &mlir_mod) {
   return applyMemRefDCE(mod);
 }
 
-static MlirModule UnifyKernels(MlirModule &mlir_mod1, MlirModule &mlir_mod2) {
+static MlirModule UnifyKernels(MlirModule &mlir_mod1, MlirModule &mlir_mod2, MlirContext &mlir_context) {
   auto mod1 = unwrap(mlir_mod1);
   auto mod2 = unwrap(mlir_mod2);
-  return wrap(applyUnifyKernels(mod1, mod2));
+  auto context = unwrap(mlir_context);
+  return wrap(applyUnifyKernels(mod1, mod2, context));
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Bindings/Python/HCLModule.cpp
+++ b/lib/Bindings/Python/HCLModule.cpp
@@ -157,7 +157,8 @@ static bool memRefDCE(MlirModule &mlir_mod) {
   return applyMemRefDCE(mod);
 }
 
-static MlirModule UnifyKernels(MlirModule &mlir_mod1, MlirModule &mlir_mod2, MlirContext &mlir_context) {
+static MlirModule UnifyKernels(MlirModule &mlir_mod1, MlirModule &mlir_mod2,
+                               MlirContext &mlir_context) {
   auto mod1 = unwrap(mlir_mod1);
   auto mod2 = unwrap(mlir_mod2);
   auto context = unwrap(mlir_context);

--- a/lib/Bindings/Python/HCLModule.cpp
+++ b/lib/Bindings/Python/HCLModule.cpp
@@ -157,6 +157,12 @@ static bool memRefDCE(MlirModule &mlir_mod) {
   return applyMemRefDCE(mod);
 }
 
+static MlirModule UnifyKernels(MlirModule &mlir_mod1, MlirModule &mlir_mod2) {
+  auto mod1 = unwrap(mlir_mod1);
+  auto mod2 = unwrap(mlir_mod2);
+  return wrap(applyUnifyKernels(mod1, mod2));
+}
+
 //===----------------------------------------------------------------------===//
 // HCL Python module definition
 //===----------------------------------------------------------------------===//
@@ -259,4 +265,5 @@ PYBIND11_MODULE(_hcl, m) {
 
   // Utility pass APIs.
   hcl_m.def("memref_dce", &memRefDCE);
+  hcl_m.def("unify_kernels", &UnifyKernels);
 }

--- a/lib/Transforms/CMakeLists.txt
+++ b/lib/Transforms/CMakeLists.txt
@@ -11,6 +11,7 @@ add_mlir_library(MLIRHCLPasses
     MemRefDCE.cpp
     DataPlacement.cpp
     TransformInterpreter.cpp
+    UnifyKernels.cpp
 
     ADDITIONAL_HEADER_DIRS
     ${PROJECT_SOURCE_DIR}/include/hcl

--- a/lib/Transforms/UnifyKernels.cpp
+++ b/lib/Transforms/UnifyKernels.cpp
@@ -1,0 +1,342 @@
+/*
+ * Copyright HeteroCL authors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <iostream>
+
+#include "PassDetail.h"
+
+#include "hcl/Dialect/HeteroCLDialect.h"
+#include "hcl/Dialect/HeteroCLOps.h"
+#include "hcl/Dialect/HeteroCLTypes.h"
+#include "hcl/Transforms/Passes.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/OperationSupport.h"
+#include "mlir/IR/AffineMap.h"
+
+using namespace mlir;
+using namespace hcl;
+
+namespace mlir {
+namespace hcl {
+
+bool compareAffineExprs(AffineExpr lhsExpr, AffineExpr rhsExpr) {
+  // Compare the kinds of affine exprs
+  if (lhsExpr.getKind() != rhsExpr.getKind()) {
+    return false;
+  }
+
+  // Compare affine exprs based on kind
+  switch (lhsExpr.getKind()) {
+    case AffineExprKind::Constant: {
+      auto lhsConst = lhsExpr.cast<AffineConstantExpr>();
+      auto rhsConst = rhsExpr.cast<AffineConstantExpr>();
+      return lhsConst.getValue() == rhsConst.getValue();
+    }
+    case AffineExprKind::DimId: {
+      auto lhsDim = lhsExpr.cast<AffineDimExpr>();
+      auto rhsDim = rhsExpr.cast<AffineDimExpr>();
+      return lhsDim.getPosition() == rhsDim.getPosition();
+    }
+    case AffineExprKind::SymbolId: {
+      auto lhsSymbol = lhsExpr.cast<AffineSymbolExpr>();
+      auto rhsSymbol = rhsExpr.cast<AffineSymbolExpr>();
+      return lhsSymbol.getPosition() == rhsSymbol.getPosition();
+    }
+    case AffineExprKind::Add:
+    case AffineExprKind::Mul:
+    case AffineExprKind::Mod:
+    case AffineExprKind::FloorDiv:
+    case AffineExprKind::CeilDiv: {
+      auto lhsBinary = lhsExpr.cast<AffineBinaryOpExpr>();
+      auto rhsBinary = rhsExpr.cast<AffineBinaryOpExpr>();
+      return compareAffineExprs(lhsBinary.getLHS(), rhsBinary.getLHS()) &&
+              compareAffineExprs(lhsBinary.getRHS(), rhsBinary.getRHS());
+    }
+  }
+  return false;
+}
+
+bool compareAffineMaps(AffineMap lhsMap, AffineMap rhsMap) {
+  AffineMap simplifiedLhsMap = simplifyAffineMap(lhsMap);
+  AffineMap simplifiedRhsMap = simplifyAffineMap(rhsMap);
+
+  if (simplifiedLhsMap.getNumDims() != simplifiedRhsMap.getNumDims() &&
+      simplifiedLhsMap.getNumSymbols() != simplifiedRhsMap.getNumSymbols() &&
+      simplifiedLhsMap.getNumResults() != simplifiedRhsMap.getNumResults()) 
+    return false;
+
+  // Compare exprs
+  for (unsigned i = 0; i < simplifiedLhsMap.getNumResults(); ++i) {
+    if (!compareAffineExprs(simplifiedLhsMap.getResult(i), simplifiedRhsMap.getResult(i))) {
+      return false;
+    }
+  }
+
+  // Todo: Might need to compare operands or use evaluation to compare
+  return true;
+}
+
+bool compareAffineForOps(affine::AffineForOp &affineForOp1, affine::AffineForOp &affineForOp2) {
+  if (affineForOp1 == affineForOp2)
+    return true;
+
+  if (affineForOp1.getStep() != affineForOp2.getStep()) return false;
+  if (!compareAffineMaps(affineForOp1.getLowerBoundMap(), affineForOp2.getLowerBoundMap()) ||
+      !compareAffineMaps(affineForOp1.getUpperBoundMap(), affineForOp2.getUpperBoundMap()))
+    return false;
+  return true;
+}
+
+void mergeLoop(OpBuilder &builder, affine::AffineForOp &op1, affine::AffineForOp &op2, Value conditionArg, bool &foundDifference) {
+  auto loc = op1->getLoc();
+
+  // Save insertion point
+  OpBuilder::InsertionGuard guard(builder);
+
+  // Create new affine.for with same arguments
+  auto lowerBoundMap = op1.getLowerBoundMap();
+  auto lowerBoundOperands = llvm::SmallVector<Value, 4>(op1.getLowerBoundOperands().begin(), op1.getLowerBoundOperands().end());
+  auto upperBoundMap = op1.getUpperBoundMap();
+  auto upperBoundOperands = llvm::SmallVector<Value, 4>(op1.getUpperBoundOperands().begin(), op1.getUpperBoundOperands().end());
+  int64_t step = op1.getStep();
+
+  auto newAffineForOp = builder.create<mlir::affine::AffineForOp>(
+      loc, lowerBoundOperands, lowerBoundMap, upperBoundOperands, upperBoundMap, step);
+
+  Block *body1 = op1.getBody();
+  Block *body2 = op2.getBody();
+  Block *newBody = newAffineForOp.getBody();
+
+  // Set insertion point to current loop body
+  builder.setInsertionPointToStart(newBody);
+
+  auto body1It = body1->begin();
+  auto body2It = body2->begin();
+
+  // Iterate over two FuncOps to find branch location
+  while (body1It != body1->end() && body2It != body2->end()) {
+    if (!foundDifference) {
+      if (!(&(*body1It) == &(*body2It))) {
+        // If we found an affine.for to merge
+        // Todo: Support dynamic loop range
+        auto affineForOp1 = dyn_cast<affine::AffineForOp>(&(*body1It));
+        auto affineForOp2 = dyn_cast<affine::AffineForOp>(&(*body2It));
+        if (affineForOp1 && affineForOp2 && 
+            compareAffineForOps(affineForOp1, affineForOp2)) {
+          mergeLoop(builder, affineForOp1, affineForOp2, conditionArg, foundDifference);
+        }
+        else {
+          foundDifference = true;
+          break;
+        }
+      } else {
+        builder.clone(*body1It);
+      }
+      ++body1It;
+      ++body2It;
+    } else {
+      break;
+    }
+  }
+
+  // Create branch for the rest after difference is found
+  IRMapping mapping1;
+  IRMapping mapping2;
+  builder.create<scf::IfOp>(
+    loc, conditionArg,
+    [&](OpBuilder &thenBuilder, Location thenLoc) {
+      while (body1It != body1->end()) {
+        thenBuilder.clone(*body1It, mapping1);
+        ++body1It;
+      }
+      thenBuilder.create<scf::YieldOp>(thenLoc);
+    },
+    [&](OpBuilder &elseBuilder, Location elseLoc) {
+      while (body2It != body2->end()) {
+        elseBuilder.clone(*body2It, mapping2);
+        ++body2It;
+      }
+      elseBuilder.create<scf::YieldOp>(elseLoc);
+    }
+  );
+}
+
+void printIRMapping(mlir::IRMapping &mapping) {
+    llvm::outs() << "IRMapping contents:\n";
+    for (auto &kv : mapping.getValueMap()) {
+        llvm::outs() << "From Value: " << kv.first << " To Value: " << kv.second << "\n";
+    }
+
+    for (auto &kv : mapping.getBlockMap()) {
+        llvm::outs() << "From Block: ";
+        kv.first->print(llvm::outs());
+        llvm::outs() << " To Block: ";
+        kv.second->print(llvm::outs());
+        llvm::outs() << "\n";
+    }
+}
+
+func::FuncOp unifyKernels(func::FuncOp &func1, func::FuncOp &func2, OpBuilder &builder) {
+  std::string newFuncName = func1.getName().str() + "_" + func2.getName().str() + "_unified";
+
+  // Todo: Now assuming return types and input types are the same
+  // Create new FuncOp with additional parameter
+  auto oldFuncType = func1.getFunctionType();
+  auto oldInputTypes = oldFuncType.getInputs();
+  auto resultTypes = oldFuncType.getResults();
+  auto loc = builder.getUnknownLoc();
+  SmallVector<Type, 4> newInputTypes(oldInputTypes.begin(), oldInputTypes.end());
+  Type instType = builder.getI1Type();
+  newInputTypes.push_back(instType);
+  auto newFuncType = builder.getFunctionType(newInputTypes, resultTypes);
+  auto newFuncOp = func::FuncOp::create(loc, newFuncName, newFuncType);
+
+  // Create new block for insertion
+  Block *entryBlock = newFuncOp.addEntryBlock();
+  auto conditionArg = entryBlock->getArgument(entryBlock->getNumArguments() - 1);
+  builder.setInsertionPointToStart(entryBlock);
+
+  auto &block1 = func1.front();
+  auto &block2 = func2.front();
+  auto block1It = block1.begin();
+  auto block2It = block2.begin();
+  bool foundDifference = false;
+
+  // Iterate over two FuncOps to find branch location
+  while (block1It != block1.end() && block2It != block2.end()) {
+    if (!foundDifference) {      
+      if (!(&(*block1It) == &(*block2It))) {
+        // If we found an affine.for to merge
+        // Todo: Support dynamic loop range
+        auto affineForOp1 = dyn_cast<affine::AffineForOp>(&(*block1It));
+        auto affineForOp2 = dyn_cast<affine::AffineForOp>(&(*block2It));
+        if (affineForOp1 && affineForOp2 && 
+            compareAffineForOps(affineForOp1, affineForOp2)) {
+          mergeLoop(builder, affineForOp1, affineForOp2, conditionArg, foundDifference);
+        }
+        else {
+          foundDifference = true;
+          break;
+        }
+      } else {
+        builder.clone(*block1It);
+      }
+      ++block1It;
+      ++block2It;
+    } else {
+      break;
+    }
+  }
+
+  // Create branch for the rest after difference is found
+  IRMapping mapping1;
+  IRMapping mapping2;
+  // builder.create<scf::IfOp>(
+  //   loc, conditionArg,
+  //   [&](OpBuilder &thenBuilder, Location thenLoc) {
+  //     for (size_t i = 0; i < block1.getNumArguments(); ++i) {
+  //       mapping1.map(block1.getArgument(i), entryBlock->getArgument(i));
+  //     }
+  //     while (block1It != block1.end()) {
+  //       auto &op = *block1It;
+  //       if (auto returnOp = dyn_cast<func::ReturnOp>(&op)) {
+  //         break;
+  //       }
+  //       thenBuilder.clone(*block1It, mapping1);
+  //       ++block1It;
+  //     }
+  //     thenBuilder.create<scf::YieldOp>(thenLoc);
+  //   },
+  //   [&](OpBuilder &elseBuilder, Location elseLoc) {
+  //     for (size_t i = 0; i < block2.getNumArguments(); ++i) {
+  //       mapping2.map(block2.getArgument(i), entryBlock->getArgument(i));
+  //     }
+  //     while (block2It != block2.end()) {
+  //       auto &op = *block2It;
+  //       if (auto returnOp = dyn_cast<func::ReturnOp>(&op)) {
+  //         break;
+  //       }
+  //       elseBuilder.clone(*block2It, mapping2);
+  //       ++block2It;
+  //     }
+  //     elseBuilder.create<scf::YieldOp>(elseLoc);
+  //   }
+  // );
+  auto ifOp = builder.create<scf::IfOp>(loc, conditionArg, /*hasElse*/ true);
+
+  // Create then block
+  builder.setInsertionPointToStart(ifOp.thenBlock());
+  for (size_t i = 0; i < block1.getNumArguments(); ++i) {
+    mapping1.map(block1.getArgument(i), entryBlock->getArgument(i));
+  }
+  while (block1It != block1.end()) {
+    auto &op = *block1It;
+    if (auto returnOp = dyn_cast<func::ReturnOp>(&op)) {
+      break;
+    }
+    builder.clone(*block1It, mapping1);
+    ++block1It;
+  }
+
+  // Create else block
+  builder.setInsertionPointToStart(ifOp.elseBlock());
+  for (size_t i = 0; i < block2.getNumArguments(); ++i) {
+    mapping2.map(block2.getArgument(i), entryBlock->getArgument(i));
+  }
+  while (block2It != block2.end()) {
+    auto &op = *block2It;
+    if (auto returnOp = dyn_cast<func::ReturnOp>(&op)) {
+      break;
+    }
+    builder.clone(*block2It, mapping2);
+    ++block2It;
+  }
+
+  // Create return Op
+  builder.setInsertionPointAfter(ifOp);
+
+  printIRMapping(mapping1);
+  printIRMapping(mapping2);
+
+  builder.clone(*block1It, mapping1);
+  // builder.clone(*block2It, mapping2);
+
+  return newFuncOp;
+}
+
+/// Pass entry point
+ModuleOp applyUnifyKernels(ModuleOp &module1, ModuleOp &module2) {
+  auto funcOps1 = module1.getOps<func::FuncOp>();
+  auto funcOps2 = module2.getOps<func::FuncOp>();
+
+  auto it1 = funcOps1.begin();
+  auto it2 = funcOps2.begin();
+
+  MLIRContext *context = module1.getContext();
+  OpBuilder builder(context);
+
+  //
+  ModuleOp newModule = ModuleOp::create(module1.getLoc());
+
+  while (it1 != funcOps1.end() && it2 != funcOps2.end()) {
+    func::FuncOp funcOp1 = *it1;
+    func::FuncOp funcOp2 = *it2;
+    func::FuncOp newFuncOp = unifyKernels(funcOp1, funcOp2, builder);
+    newModule.push_back(newFuncOp);
+
+    ++it1;
+    ++it2;
+  }
+
+  return newModule;
+}
+
+} // namespace hcl
+} // namespace mlir

--- a/lib/Transforms/UnifyKernels.cpp
+++ b/lib/Transforms/UnifyKernels.cpp
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <iostream>
-
 #include "PassDetail.h"
 
 #include "hcl/Dialect/HeteroCLDialect.h"

--- a/tools/hcl-opt/hcl-opt.cpp
+++ b/tools/hcl-opt/hcl-opt.cpp
@@ -243,201 +243,136 @@ int runJiTCompiler(mlir::ModuleOp module) {
   return 0;
 }
 
-void test() {
-  #include "mlir/Dialect/Func/IR/FuncOps.h"
-  #include "mlir/Dialect/SCF/IR/SCF.h"
-  #include "mlir/Dialect/Arith/IR/Arith.h"
-  // 创建一个 MLIRContext
-    mlir::MLIRContext context;
-    context.getOrLoadDialect<mlir::func::FuncDialect>();
-  context.getOrLoadDialect<mlir::scf::SCFDialect>();
-
-    // 创建第一个 ModuleOp
-    mlir::OpBuilder builder1(&context);
-    auto module1 = mlir::ModuleOp::create(builder1.getUnknownLoc());
-
-    // 在 module1 中添加一个空函数
-    builder1.setInsertionPointToEnd(module1.getBody());
-    mlir::FunctionType funcType1 = builder1.getFunctionType({}, builder1.getI32Type());
-    mlir::func::FuncOp func1 = builder1.create<mlir::func::FuncOp>(
-        builder1.getUnknownLoc(),
-        "func1",
-        funcType1
-    );
-    mlir::Block *entryBlock1 = func1.addEntryBlock();
-
-    // 在函数中添加常量和返回操作
-    builder1.setInsertionPointToStart(entryBlock1);
-    auto constant1 = builder1.create<mlir::arith::ConstantOp>(
-        builder1.getUnknownLoc(),
-        builder1.getI32Type(),
-        builder1.getI32IntegerAttr(42) // 常量值为 42
-    );
-    builder1.create<mlir::func::ReturnOp>(builder1.getUnknownLoc(), constant1.getResult());
-
-    // 打印第一个 ModuleOp
-    module1.dump();
-
-    // 创建第二个 ModuleOp
-    mlir::OpBuilder builder2(&context);
-    auto module2 = mlir::ModuleOp::create(builder2.getUnknownLoc());
-
-    // 在 module2 中添加一个空函数
-    mlir::FunctionType funcType2 = builder2.getFunctionType({}, builder2.getI32Type());
-    builder2.setInsertionPointToEnd(module2.getBody());
-    mlir::func::FuncOp func2 = builder2.create<mlir::func::FuncOp>(
-        builder2.getUnknownLoc(),
-        "func2",
-        funcType2
-    );
-    mlir::Block *entryBlock2 = func2.addEntryBlock();
-
-    // 在函数中添加常量和返回操作
-    builder2.setInsertionPointToStart(entryBlock2);
-    auto constant2 = builder2.create<mlir::arith::ConstantOp>(
-        builder2.getUnknownLoc(),
-        builder2.getI32Type(),
-        builder2.getI32IntegerAttr(7) // 常量值为 7
-    );
-    builder2.create<mlir::func::ReturnOp>(builder2.getUnknownLoc(), constant2.getResult());
-
-    // 打印第二个 ModuleOp
-    module2.dump();
-
-    // mlir::hcl::applyUnifyKernels(module1, module2);
-}
-
 int main(int argc, char **argv) {
-  test();
   // Register dialects and passes in current context
-  // mlir::DialectRegistry registry;
-  // mlir::registerAllDialects(registry);
-  // registry.insert<mlir::hcl::HeteroCLDialect>();
-  // mlir::hcl::registerTransformDialectExtension(registry);
+  mlir::DialectRegistry registry;
+  mlir::registerAllDialects(registry);
+  registry.insert<mlir::hcl::HeteroCLDialect>();
+  mlir::hcl::registerTransformDialectExtension(registry);
 
-  // mlir::MLIRContext context;
-  // context.appendDialectRegistry(registry);
-  // context.allowUnregisteredDialects(true);
-  // context.printOpOnDiagnostic(true);
-  // context.loadAllAvailableDialects();
+  mlir::MLIRContext context;
+  context.appendDialectRegistry(registry);
+  context.allowUnregisteredDialects(true);
+  context.printOpOnDiagnostic(true);
+  context.loadAllAvailableDialects();
 
-  // mlir::registerAllPasses();
-  // mlir::hcl::registerHCLPasses();
-  // mlir::hcl::registerHCLConversionPasses();
+  mlir::registerAllPasses();
+  mlir::hcl::registerHCLPasses();
+  mlir::hcl::registerHCLConversionPasses();
 
-  // // Parse pass names in main to ensure static initialization completed
-  // llvm::cl::ParseCommandLineOptions(argc, argv,
-  //                                   "MLIR modular optimizer driver\n");
+  // Parse pass names in main to ensure static initialization completed
+  llvm::cl::ParseCommandLineOptions(argc, argv,
+                                    "MLIR modular optimizer driver\n");
 
-  // mlir::OwningOpRef<mlir::ModuleOp> module;
-  // if (int error = loadMLIR(context, module))
-  //   return error;
+  mlir::OwningOpRef<mlir::ModuleOp> module;
+  if (int error = loadMLIR(context, module))
+    return error;
 
-  // // Initialize a pass manager
-  // // https://mlir.llvm.org/docs/PassManagement/
-  // // Operation agnostic passes
-  // mlir::PassManager pm(&context);
-  // // Operation specific passes
-  // mlir::OpPassManager &optPM = pm.nest<mlir::func::FuncOp>();
-  // if (enableOpt) {
-  //   pm.addPass(mlir::hcl::createLoopTransformationPass());
-  // }
+  // Initialize a pass manager
+  // https://mlir.llvm.org/docs/PassManagement/
+  // Operation agnostic passes
+  mlir::PassManager pm(&context);
+  // Operation specific passes
+  mlir::OpPassManager &optPM = pm.nest<mlir::func::FuncOp>();
+  if (enableOpt) {
+    pm.addPass(mlir::hcl::createLoopTransformationPass());
+  }
 
-  // if (dataPlacement) {
-  //   pm.addPass(mlir::hcl::createDataPlacementPass());
-  // }
+  if (dataPlacement) {
+    pm.addPass(mlir::hcl::createDataPlacementPass());
+  }
 
-  // if (memRefDCE) {
-  //   pm.addPass(mlir::hcl::createMemRefDCEPass());
-  // }
+  if (memRefDCE) {
+    pm.addPass(mlir::hcl::createMemRefDCEPass());
+  }
 
-  // if (lowerComposite) {
-  //   pm.addPass(mlir::hcl::createLowerCompositeTypePass());
-  // }
+  if (lowerComposite) {
+    pm.addPass(mlir::hcl::createLowerCompositeTypePass());
+  }
 
-  // if (fixedPointToInteger) {
-  //   pm.addPass(mlir::hcl::createFixedPointToIntegerPass());
-  // }
+  if (fixedPointToInteger) {
+    pm.addPass(mlir::hcl::createFixedPointToIntegerPass());
+  }
 
-  // // lowerPrintOps should be run after lowering fixed point to integer
-  // if (lowerPrintOps) {
-  //   pm.addPass(mlir::hcl::createLowerPrintOpsPass());
-  // }
+  // lowerPrintOps should be run after lowering fixed point to integer
+  if (lowerPrintOps) {
+    pm.addPass(mlir::hcl::createLowerPrintOpsPass());
+  }
 
-  // if (anyWidthInteger) {
-  //   pm.addPass(mlir::hcl::createAnyWidthIntegerPass());
-  // }
+  if (anyWidthInteger) {
+    pm.addPass(mlir::hcl::createAnyWidthIntegerPass());
+  }
 
-  // if (moveReturnToInput) {
-  //   pm.addPass(mlir::hcl::createMoveReturnToInputPass());
-  // }
+  if (moveReturnToInput) {
+    pm.addPass(mlir::hcl::createMoveReturnToInputPass());
+  }
 
-  // if (lowerBitOps) {
-  //   pm.addPass(mlir::hcl::createLowerBitOpsPass());
-  // }
+  if (lowerBitOps) {
+    pm.addPass(mlir::hcl::createLowerBitOpsPass());
+  }
 
-  // if (legalizeCast) {
-  //   pm.addPass(mlir::hcl::createLegalizeCastPass());
-  // }
+  if (legalizeCast) {
+    pm.addPass(mlir::hcl::createLegalizeCastPass());
+  }
 
-  // if (removeStrideMap) {
-  //   pm.addPass(mlir::hcl::createRemoveStrideMapPass());
-  // }
+  if (removeStrideMap) {
+    pm.addPass(mlir::hcl::createRemoveStrideMapPass());
+  }
 
-  // if (bufferization) {
-  //   pm.addPass(mlir::bufferization::createOneShotBufferizePass());
-  // }
+  if (bufferization) {
+    pm.addPass(mlir::bufferization::createOneShotBufferizePass());
+  }
 
-  // if (linalgConversion) {
-  //   optPM.addPass(mlir::createConvertLinalgToAffineLoopsPass());
-  // }
+  if (linalgConversion) {
+    optPM.addPass(mlir::createConvertLinalgToAffineLoopsPass());
+  }
 
-  // if (enableNormalize) {
-  //   // To make all loop steps to 1.
-  //   optPM.addPass(mlir::affine::createAffineLoopNormalizePass());
+  if (enableNormalize) {
+    // To make all loop steps to 1.
+    optPM.addPass(mlir::affine::createAffineLoopNormalizePass());
 
-  //   // Sparse Conditional Constant Propagation (SCCP)
-  //   pm.addPass(mlir::createSCCPPass());
+    // Sparse Conditional Constant Propagation (SCCP)
+    pm.addPass(mlir::createSCCPPass());
 
-  //   // To factor out the redundant AffineApply/AffineIf operations.
-  //   // optPM.addPass(mlir::createCanonicalizerPass());
-  //   // optPM.addPass(mlir::createSimplifyAffineStructuresPass());
+    // To factor out the redundant AffineApply/AffineIf operations.
+    // optPM.addPass(mlir::createCanonicalizerPass());
+    // optPM.addPass(mlir::createSimplifyAffineStructuresPass());
 
-  //   // To simplify the memory accessing.
-  //   pm.addPass(mlir::memref::createNormalizeMemRefsPass());
+    // To simplify the memory accessing.
+    pm.addPass(mlir::memref::createNormalizeMemRefsPass());
 
-  //   // Generic common sub expression elimination.
-  //   // pm.addPass(mlir::createCSEPass());
-  // }
+    // Generic common sub expression elimination.
+    // pm.addPass(mlir::createCSEPass());
+  }
 
-  // if (applyTransform)
-  //   pm.addPass(mlir::hcl::createTransformInterpreterPass());
+  if (applyTransform)
+    pm.addPass(mlir::hcl::createTransformInterpreterPass());
 
-  // if (runJiT || lowerToLLVM) {
-  //   if (!removeStrideMap) {
-  //     pm.addPass(mlir::hcl::createRemoveStrideMapPass());
-  //   }
-  //   pm.addPass(mlir::hcl::createHCLToLLVMLoweringPass());
-  // }
+  if (runJiT || lowerToLLVM) {
+    if (!removeStrideMap) {
+      pm.addPass(mlir::hcl::createRemoveStrideMapPass());
+    }
+    pm.addPass(mlir::hcl::createHCLToLLVMLoweringPass());
+  }
 
-  // // Run the pass pipeline
-  // if (mlir::failed(pm.run(*module))) {
-  //   return 4;
-  // }
+  // Run the pass pipeline
+  if (mlir::failed(pm.run(*module))) {
+    return 4;
+  }
 
-  // // print output
-  // std::string errorMessage;
-  // auto outfile = mlir::openOutputFile(outputFilename, &errorMessage);
-  // if (!outfile) {
-  //   llvm::errs() << errorMessage << "\n";
-  //   return 2;
-  // }
-  // module->print(outfile->os());
-  // outfile->os() << "\n";
+  // print output
+  std::string errorMessage;
+  auto outfile = mlir::openOutputFile(outputFilename, &errorMessage);
+  if (!outfile) {
+    llvm::errs() << errorMessage << "\n";
+    return 2;
+  }
+  module->print(outfile->os());
+  outfile->os() << "\n";
 
-  // // run JiT
-  // if (runJiT)
-  //   return runJiTCompiler(*module);
+  // run JiT
+  if (runJiT)
+    return runJiTCompiler(*module);
 
   return 0;
 }


### PR DESCRIPTION
Create a MLIR level unify functionality for two kernels. Merge the same affine for loop and use conditional branch to support different logic.